### PR TITLE
Pull in upstream updates from cisagov/skeleton-ansible-role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.mypy_cache
 __pycache__
 .python-version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.0.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -74,7 +74,7 @@ repos:
     rev: v4.2.0
     hooks:
       - id: ansible-lint
-        # files: molecule/default/playbook.yml
+      # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.12.0
     hooks:
@@ -88,3 +88,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.761
+    hooks:
+      - id: mypy

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,10 +16,10 @@ galaxy_info:
     - name: Fedora
       versions:
         - 29
-          # Ansible currently insists on installing python2-dnf, which does
-          # not exist in Fedora 30.  Until that is resolved, we can't use
-          # Fedora 30.
-          # - 30
+        # Ansible currently insists on installing python2-dnf, which
+        # does not exist in Fedora 30.  Until that is resolved, we
+        # can't use Fedora 30.
+        # - 30
         - 31
   galaxy_tags:
     - skeleton

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,14 @@ galaxy_info:
     - name: Amazon
       versions:
         - 2018.03
+    - name: Fedora
+      versions:
+        - 29
+          # Ansible currently insists on installing python2-dnf, which does
+          # not exist in Fedora 30.  Until that is resolved, we can't use
+          # Fedora 30.
+          # - 30
+        - 31
   galaxy_tags:
     - skeleton
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,13 +6,13 @@ galaxy_info:
   license: CC0
   min_ansible_version: 2.0
   platforms:
+    - name: Amazon
+      versions:
+        - 2018.03
     - name: Debian
       versions:
         - stretch
         - buster
-    - name: Amazon
-      versions:
-        - 2018.03
     - name: Fedora
       versions:
         - 29

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,8 +12,13 @@ platforms:
     image: debian:buster-slim
   - name: fedora29
     image: fedora:29
-  - name: fedora30
-    image: fedora:30
+  # Ansible currently insists on installing python2-dnf, which does
+  # not exist in Fedora 30.  Until that is resolved, we can't use
+  # Fedora 30.
+  # - name: fedora30
+  #   image: fedora:30
+  - name: fedora31
+    image: fedora:31
   - name: amazon2018.03
     image: amazonlinux:2018.03
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,6 +6,8 @@ driver:
 lint:
   name: yamllint
 platforms:
+  - name: amazon2018.03
+    image: amazonlinux:2018.03
   - name: debian9
     image: debian:stretch-slim
   - name: debian10
@@ -19,8 +21,6 @@ platforms:
   #   image: fedora:30
   - name: fedora31
     image: fedora:31
-  - name: amazon2018.03
-    image: amazonlinux:2018.03
 provisioner:
   name: ansible
   lint:


### PR DESCRIPTION
## 🗣 Description

Pull in upstream updates from [cisagov/skeleton-ansible-role](https://github.com/cisagov/skeleton-ansible.role).

## 💭 Motivation and Context

While working on cisagov/ansible-role-docker#12, I realized that this repo was out of date with respect to cisagov/skeleton-ansible-role.  I could not let this injustice stand.

## 🧪 Testing

All the pre-commit hooks and GitHub Action checks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
