### PR TITLE
Install python-minimal and python3-minimal for Debian-based distributions

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -27,14 +27,14 @@ def test_python(host, pkg):
         assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize("pkg", ["python-apt"])
+@pytest.mark.parametrize("pkg", ["python-apt", "python-minimal"])
 def test_python_apt(host, pkg):
     """Test that the appropriate packages were installed."""
     if host.system_info.distribution == "debian" and host.system_info.release == "9.12":
         assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize("pkg", ["python3-apt"])
+@pytest.mark.parametrize("pkg", ["python3-apt", "python3-minimal"])
 def test_python3_apt(host, pkg):
     """Test that the appropriate packages were installed."""
     if (

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,3 +6,5 @@ package_names:
   - python3
   # This ensures that Ansible can install packages using python3
   - python3-apt
+  # This provides the /usr/bin/python3 symlink
+  - python3-minimal

--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -11,3 +11,7 @@ package_names:
   # python3
   - python-apt
   - python3-apt
+  # These packages provide the /usr/bin/python and /usr/bin/python3
+  # symlinks
+  - python-minimal
+  - python3-minimal


### PR DESCRIPTION
## 🗣 Description

This pull request adds the installation of the `python-minimal` and `python3-minimal` packages where appropriate for Debian-based distributions.

## 💭 Motivation and Context

`python-minimal` and `python3-minimal` provide the `/usr/bin/python` and `/usr/bin/python3` symlinks, respectively.  There are useful, for example, in the case where both `/usr/bin/python3.7` and `/usr/bin/python3.8` are both present and Ansible is choosing the wrong one.  (This is currently happening when building the Kali Linux AMI for the COOL.)

## 🧪 Testing

I was able to use these changes to successfully build a new Kali Linux AMI for the COOL.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
