### PR TITLE
Install Python2 on Debian Buster

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,25 +12,27 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("pkg", ["python3"])
+@pytest.mark.parametrize("pkg", ["python"])
 def test_python(host, pkg):
     """Test that the appropriate packages were installed."""
-    if (
-        (
-            host.system_info.distribution == "debian"
-            and host.system_info.release != "9.12"
-        )
-        or host.system_info.distribution == "redhat"
-        or host.system_info.distribution == "kali"
-        or host.system_info.distribution == "amzn"
+    if host.system_info.distribution == "debian" and (
+        host.system_info.codename == "stretch" or host.system_info.codename == "buster"
     ):
         assert host.package(pkg).is_installed
+
+
+@pytest.mark.parametrize("pkg", ["python3"])
+def test_python3(host, pkg):
+    """Test that the appropriate packages were installed."""
+    assert host.package(pkg).is_installed
 
 
 @pytest.mark.parametrize("pkg", ["python-apt", "python-minimal"])
 def test_python_apt(host, pkg):
     """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "debian" and host.system_info.release == "9.12":
+    if host.system_info.distribution == "debian" and (
+        host.system_info.codename == "stretch" or host.system_info.codename == "buster"
+    ):
         assert host.package(pkg).is_installed
 
 
@@ -55,11 +57,4 @@ def test_python3_dnf(host, pkg):
 def test_python3_rpm(host, pkg):
     """Test that the appropriate packages were installed."""
     if host.system_info.distribution == "amzn":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["python", "python3"])
-def test_python_debian_9(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "debian" and host.system_info.release == "9.12":
         assert host.package(pkg).is_installed

--- a/vars/Debian_buster.yml
+++ b/vars/Debian_buster.yml
@@ -1,0 +1,1 @@
+Debian_stretch.yml


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates this role to install Python 2 on both Debian Stretch and Debian Buster.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Now that no COOL instances are on Debian Buster we can allow Python 2 to install on that release which will allow us to update the versions of Debian used in [cisagov/cyhy_amis]. This allows us to proceed with migrating away from Debian Stretch, which as Debian's `oldoldstable` which will lose the last bits of support in July of this year (2022).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I have this as part of a testing environment for [cisagov/cyhy_amis] and I can confirm I have Python 2 on Debian Buster AMIs.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

[cisagov/cyhy_amis]: https://github.com/cisagov/cyhy_amis