### PR TITLE
Control installation of Python 2 via a role variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,7 @@ jobs:
       matrix:
         scenario:
           - default
+          - python2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
     hooks:
       - id: bandit
         # Bandit complains about the use of assert() in tests
-        exclude: molecule/default/tests
+        exclude: molecule/(default|python2)/tests
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black

--- a/README.md
+++ b/README.md
@@ -14,14 +14,9 @@ apply.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| install_python2 | A boolean indicating whether or not to install Python 2 alongside Python 3. | `false` | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ with this waiver of copyright interest.
 
 ## Author Information ##
 
-Jeremy Frasier - <jeremy.frasier@trio.dhs.gov>
+Shane Frasier - <jeremy.frasier@trio.dhs.gov>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ apply.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| install_python2 | A boolean indicating whether or not to install Python 2 alongside Python 3. | `false` | No |
+| install_python2 | A boolean indicating whether or not to install Python 2 alongside Python 3.  Where possible, we also install the necessary dependencies to use Python 2 as Ansible's discovered Python; unfortunately, this is only possible on Amazon Linux 2, Debian Stretch, Debian Buster, and Ubuntu Bionic. | `false` | No |
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Whether or not to install Python 2 alongside Python 3
+install_python2: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: Jeremy Frasier
+  author: Shane Frasier
   description: Ansible role for installing Python
   company: CISA Cyber Assessments
   galaxy_tags:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,7 +4,6 @@
 import os
 
 # Third-Party Libraries
-import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -12,54 +11,18 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("pkg", ["python3"])
-def test_python(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if (
-        (
-            host.system_info.distribution == "debian"
-            and host.system_info.release != "9.12"
-        )
-        or host.system_info.distribution == "redhat"
-        or host.system_info.distribution == "kali"
-        or host.system_info.distribution == "amzn"
-    ):
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["python-apt", "python-minimal"])
-def test_python_apt(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "debian" and host.system_info.release == "9.12":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["python3-apt", "python3-minimal"])
-def test_python3_apt(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if (
-        host.system_info.distribution == "debian"
-        or host.system_info.distribution == "kali"
-    ):
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["python3-dnf"])
-def test_python3_dnf(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "redhat":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["python3-rpm"])
-def test_python3_rpm(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "amzn":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["python", "python3"])
-def test_python_debian_9(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "debian" and host.system_info.release == "9.12":
-        assert host.package(pkg).is_installed
+def test_python3_packages(host):
+    """Test that the appropriate Python 3 packages were installed."""
+    if host.system_info.distribution in ["amzn"]:
+        for p in ["python3", "python3-rpm"]:
+            assert host.package(p).is_installed
+    elif host.system_info.distribution in ["debian", "kali", "ubuntu"]:
+        for p in ["python3", "python3-apt", "python3-minimal"]:
+            assert host.package(p).is_installed
+    elif host.system_info.distribution in "fedora":
+        for p in ["python3", "python3-dnf"]:
+            assert host.package(p).is_installed
+    else:
+        assert (
+            False
+        ), f"Linux distribution {host.system_info.distribution} is not supported."

--- a/molecule/python2/Dockerfile_debian_9.j2
+++ b/molecule/python2/Dockerfile_debian_9.j2
@@ -1,0 +1,1 @@
+../default/Dockerfile_debian_9.j2

--- a/molecule/python2/INSTALL.rst
+++ b/molecule/python2/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/python2/converge.yml
+++ b/molecule/python2/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include ansible-role-python
+      ansible.builtin.include_role:
+        name: ansible-role-python
+      vars:
+        install_python2: yes

--- a/molecule/python2/molecule-no-systemd.yml
+++ b/molecule/python2/molecule-no-systemd.yml
@@ -1,0 +1,74 @@
+---
+# This molecule configuration file is suitable for testing Ansible
+# roles that _do not_ require SystemD.  If your Ansible role _does_
+# require SystemD then you should use molecule-with-systemd.yml
+# instead.
+#
+# Note that the molecule configuration file that is symlinked to
+# molecule.yml is the one that will be used.
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: amazonlinux2
+    image: amazonlinux:2
+  - name: debian9
+    image: debian:stretch-slim
+    dockerfile: Dockerfile_debian_9.j2
+  - name: debian10
+    image: debian:buster-slim
+  - name: debian11
+    image: debian:bullseye-slim
+  - name: debian12
+    image: debian:bookworm-slim
+  - name: kali
+    image: kalilinux/kali-rolling
+  - name: fedora34
+    image: fedora:34
+  - name: fedora35
+    image: fedora:35
+  - name: ubuntu18
+    image: ubuntu:bionic
+  - name: ubuntu20
+    image: ubuntu:focal
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      debian9:
+        # auto_legacy is still the default behavior until Ansible 2.12
+        # is released, but Molecule overrides this and forces the use
+        # of auto.
+        #
+        # In auto_legacy mode Ansible will prefer the /usr/bin/python
+        # interpreter if it exists, while in auto mode it will prefer
+        # the Python interpreter specified in an internal map.  In
+        # most cases we only have Python3 installed, and the internal
+        # map specifies /usr/bin/python3, so it is immaterial whether
+        # we use auto_legacy or auto.
+        #
+        # The one place where it _does_ matter is our Debian9 AKA CyHy
+        # instances.  Here the /usr/bin/python _and_ /usr/bin/python3
+        # interpreters are both installed.  In Ansible 2.10 a Debian
+        # entry was added to the internal map, so now auto_legacy
+        # selects the /usr/bin/python interpreter while auto selects
+        # the /usr/bin/python3 interpreter.  We want to maintain the
+        # auto_legacy behavior in this case since CyHy is still
+        # Python2.
+        #
+        # See:
+        # * https://github.com/ansible-community/molecule/blob/3.0.8/molecule/provisioner/ansible.py#L389
+        # * https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/config/base.yml#L1492-L1542
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/executor/interpreter_discovery.py
+        ansible_python_interpreter: auto_legacy
+scenario:
+  name: python2
+verifier:
+  name: testinfra

--- a/molecule/python2/molecule-with-systemd.yml
+++ b/molecule/python2/molecule-with-systemd.yml
@@ -1,0 +1,122 @@
+---
+# This molecule configuration file is suitable for testing Ansible
+# roles that _do_ require SystemD.  If your Ansible role _does not_
+# require SystemD then you should use molecule-no-systemd.yml instead.
+#
+# Note that the molecule configuration file that is symlinked to
+# molecule.yml is the one that will be used.
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: amazonlinux2-systemd
+    image: geerlingguy/docker-amazonlinux2-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: debian9-systemd
+    image: geerlingguy/docker-debian9-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: debian10-systemd
+    image: geerlingguy/docker-debian10-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: debian11-systemd
+    image: geerlingguy/docker-debian11-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: debian12-systemd
+    image: cisagov/docker-debian12-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: kali-systemd
+    image: cisagov/docker-kali-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: fedora34-systemd
+    image: geerlingguy/docker-fedora34-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: fedora35-systemd
+    image: geerlingguy/docker-fedora35-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: ubuntu-18-systemd
+    image: geerlingguy/docker-ubuntu1804-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: ubuntu-20-systemd
+    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      debian9-systemd:
+        # auto_legacy is still the default behavior until Ansible 2.12
+        # is released, but Molecule overrides this and forces the use
+        # of auto.
+        #
+        # In auto_legacy mode Ansible will prefer the /usr/bin/python
+        # interpreter if it exists, while in auto mode it will prefer
+        # the Python interpreter specified in an internal map.  In
+        # most cases we only have Python3 installed, and the internal
+        # map specifies /usr/bin/python3, so it is immaterial whether
+        # we use auto_legacy or auto.
+        #
+        # The one place where it _does_ matter is our Debian9 AKA CyHy
+        # instances.  Here the /usr/bin/python _and_ /usr/bin/python3
+        # interpreters are both installed.  In Ansible 2.10 a Debian
+        # entry was added to the internal map, so now auto_legacy
+        # selects the /usr/bin/python interpreter while auto selects
+        # the /usr/bin/python3 interpreter.  We want to maintain the
+        # auto_legacy behavior in this case since CyHy is still
+        # Python2.
+        #
+        # See:
+        # * https://github.com/ansible-community/molecule/blob/3.0.8/molecule/provisioner/ansible.py#L389
+        # * https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/config/base.yml#L1492-L1542
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/executor/interpreter_discovery.py
+        ansible_python_interpreter: auto_legacy
+scenario:
+  name: python2
+verifier:
+  name: testinfra

--- a/molecule/python2/molecule.yml
+++ b/molecule/python2/molecule.yml
@@ -1,0 +1,1 @@
+molecule-no-systemd.yml

--- a/molecule/python2/pip.yml
+++ b/molecule/python2/pip.yml
@@ -1,0 +1,1 @@
+../default/pip.yml

--- a/molecule/python2/prepare.yml
+++ b/molecule/python2/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/python2/requirements.yml
+++ b/molecule/python2/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/python2/tests/test_default.py
+++ b/molecule/python2/tests/test_default.py
@@ -1,0 +1,1 @@
+../../default/tests/test_default.py

--- a/molecule/python2/tests/test_python2.py
+++ b/molecule/python2/tests/test_python2.py
@@ -1,0 +1,49 @@
+"""Module containing the tests for the python2 scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+def test_python3_packages(host):
+    """Test that the appropriate Python 3 packages were installed."""
+    if host.system_info.distribution in ["amzn"]:
+        for p in ["python3", "python3-rpm"]:
+            assert host.package(p).is_installed
+    elif host.system_info.distribution in ["debian", "kali", "ubuntu"]:
+        for p in ["python3", "python3-apt", "python3-minimal"]:
+            assert host.package(p).is_installed
+    elif host.system_info.distribution in "fedora":
+        for p in ["python3", "python3-dnf"]:
+            assert host.package(p).is_installed
+    else:
+        assert (
+            False
+        ), f"Linux distribution {host.system_info.distribution} is not supported."
+
+
+def test_python2_packages(host):
+    """Test that the appropriate Python 2 packages were installed."""
+    if host.system_info.distribution in ["amzn"]:
+        for p in ["python"]:
+            assert host.package(p).is_installed
+    elif host.system_info.distribution in ["debian", "kali", "ubuntu"]:
+        if host.system_info.codename not in ["bionic", "stretch"]:
+            for p in ["python2", "python2-minimal"]:
+                assert host.package(p).is_installed
+        else:
+            for p in ["python", "python-minimal"]:
+                assert host.package(p).is_installed
+    elif host.system_info.distribution in ["fedora"]:
+        for p in ["python2.7"]:
+            assert host.package(p).is_installed
+    else:
+        assert (
+            False
+        ), f"Linux distribution {host.system_info.distribution} is not supported."

--- a/molecule/python2/tests/test_python2.py
+++ b/molecule/python2/tests/test_python2.py
@@ -14,14 +14,17 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_python2_packages(host):
     """Test that the appropriate Python 2 packages were installed."""
     if host.system_info.distribution in ["amzn"]:
-        for p in ["python"]:
+        for p in ["python", "python2-rpm"]:
             assert host.package(p).is_installed
     elif host.system_info.distribution in ["debian", "kali", "ubuntu"]:
-        if host.system_info.codename not in ["bionic", "stretch"]:
-            for p in ["python2", "python2-minimal"]:
+        if host.system_info.codename in ["bionic", "stretch"]:
+            for p in ["python", "python-apt", "python-minimal"]:
+                assert host.package(p).is_installed
+        elif host.system_info.codename in ["buster"]:
+            for p in ["python2", "python-apt", "python2-minimal"]:
                 assert host.package(p).is_installed
         else:
-            for p in ["python", "python-minimal"]:
+            for p in ["python2", "python2-minimal"]:
                 assert host.package(p).is_installed
     elif host.system_info.distribution in ["fedora"]:
         for p in ["python2.7"]:

--- a/molecule/python2/tests/test_python2.py
+++ b/molecule/python2/tests/test_python2.py
@@ -11,23 +11,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-def test_python3_packages(host):
-    """Test that the appropriate Python 3 packages were installed."""
-    if host.system_info.distribution in ["amzn"]:
-        for p in ["python3", "python3-rpm"]:
-            assert host.package(p).is_installed
-    elif host.system_info.distribution in ["debian", "kali", "ubuntu"]:
-        for p in ["python3", "python3-apt", "python3-minimal"]:
-            assert host.package(p).is_installed
-    elif host.system_info.distribution in "fedora":
-        for p in ["python3", "python3-dnf"]:
-            assert host.package(p).is_installed
-    else:
-        assert (
-            False
-        ), f"Linux distribution {host.system_info.distribution} is not supported."
-
-
 def test_python2_packages(host):
     """Test that the appropriate Python 2 packages were installed."""
     if host.system_info.distribution in ["amzn"]:

--- a/molecule/python2/upgrade.yml
+++ b/molecule/python2/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for python
-
 - name: Load var file with package names based on the OS type
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
@@ -12,6 +10,11 @@
       paths:
         - "{{ role_path }}/vars"
 
-- name: Install python
+- name: Install Python 3
   ansible.builtin.package:
-    name: '{{ package_names }}'
+    name: "{{ python3_package_names }}"
+
+- name: Install Python 2
+  ansible.builtin.package:
+    name: "{{ python2_package_names }}"
+  when: install_python2

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,8 +1,10 @@
 ---
-# vars file for Amazon Linux
+# The Python 2 package names
+python2_package_names:
+  - python
 
-# The Python package names
-package_names:
+# The Python 3 package names
+python3_package_names:
   - python3
   # This ensures that Ansible can install packages using python3
   - python3-rpm

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -2,6 +2,8 @@
 # The Python 2 package names
 python2_package_names:
   - python
+  # This ensures that Ansible can install packages using python2
+  - python2-rpm
 
 # The Python 3 package names
 python3_package_names:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,8 +1,12 @@
 ---
-# vars file for Debian
+# The Python 2 package names
+python2_package_names:
+  - python2
+  # This package provides the /usr/bin/python symlink
+  - python2-minimal
 
-# The Python package names
-package_names:
+# The Python 3 package names
+python3_package_names:
   - python3
   # This ensures that Ansible can install packages using python3
   - python3-apt

--- a/vars/Debian_buster.yml
+++ b/vars/Debian_buster.yml
@@ -1,11 +1,11 @@
 ---
 # The Python 2 package names
 python2_package_names:
-  - python
+  - python2
   # This ensures that Ansible can install packages using python2
   - python-apt
   # This package provides the /usr/bin/python symlink
-  - python-minimal
+  - python2-minimal
 
 # The Python 3 package names
 python3_package_names:

--- a/vars/Debian_stretch.yml
+++ b/vars/Debian_stretch.yml
@@ -1,17 +1,14 @@
 ---
-# vars file for Debian 9
-
-# The Python package names.  We treat Debian 9 as a special case,
-# since the CyHy AMIs (and only the CyHy AMIs) are built on it.
-# Therefore it needs python2 support.
-package_names:
+# The Python 2 package names
+python2_package_names:
   - python
-  - python3
-  # This ensures that Ansible can install packages using python2 or
-  # python3
-  - python-apt
-  - python3-apt
-  # These packages provide the /usr/bin/python and /usr/bin/python3
-  # symlinks
+  # This package provides the /usr/bin/python symlink
   - python-minimal
+
+# The Python 3 package names
+python3_package_names:
+  - python3
+  # This ensures that Ansible can install packages using python3
+  - python3-apt
+  # This provides the /usr/bin/python3 symlink
   - python3-minimal

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,8 +1,10 @@
 ---
-# vars file for RedHat
+# The Python 2 package names
+python2_package_names:
+  - python2.7
 
-# The Python package names
-package_names:
+# The Python 3 package names
+python3_package_names:
   - python3
   # This ensures that Ansible can install packages using python3
   - python3-dnf

--- a/vars/Ubuntu_bionic.yml
+++ b/vars/Ubuntu_bionic.yml
@@ -1,0 +1,1 @@
+Debian_stretch.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies this role to control the installation of Python 2 via a role variable.  Previously Python 2 was installed only on Debian Stretch.

Note that I have added the `blocked` label because this PR should be merged along with:
- cisagov/ansible-role-pip#50
- cisagov/cyhy_amis#451

## 💭 Motivation and context ##

This change is part of the work that will allow us to build CyHy AMIs on top of on newer Debian releases.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.